### PR TITLE
Bump the version on the terraform-aws-mcaf-s3 module:

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: aquasecurity/tfsec-action@v1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# TF
+.terraform/
+.terraform.lock.hcl

--- a/bucket.tf
+++ b/bucket.tf
@@ -4,5 +4,5 @@ module "deployment_bucket" {
   force_destroy = true
   versioning    = true
   tags          = var.tags
-  logging       = var.logging
+  logging       = var.logging # tfsec:ignore:aws-s3-enable-bucket-logging
 }

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,5 +1,5 @@
 module "deployment_bucket" {
-  source        = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.2.0"
+  source        = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.5.0"
   name          = local.deployment_bucket
   force_destroy = true
   versioning    = true

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,8 +1,9 @@
+# tfsec:ignore:aws-s3-enable-bucket-logging
 module "deployment_bucket" {
   source        = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.5.0"
   name          = local.deployment_bucket
   force_destroy = true
   versioning    = true
   tags          = var.tags
-  logging       = var.logging # tfsec:ignore:aws-s3-enable-bucket-logging
+  logging       = var.logging
 }

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "codepipeline_role_policy" {
       "codebuild:BatchGetBuilds",
       "codebuild:StartBuild"
     ]
-    resources = "arn:aws:codepipeline:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    resources = ["arn:aws:codepipeline:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
   }
 }
 

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -3,7 +3,10 @@ data "aws_iam_policy_document" "codepipeline_role_policy" {
     actions = [
       "s3:ListBucket",
       "s3:ListBucketVersions",
-      "s3:Get*",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectAttributes",
+      "s3:GetObjectTagging",
       "s3:PutObject"
     ]
     resources = [

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -1,7 +1,8 @@
 data "aws_iam_policy_document" "codepipeline_role_policy" {
   statement {
     actions = [
-      "s3:List*",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:Get*",
       "s3:PutObject"
     ]
@@ -16,7 +17,7 @@ data "aws_iam_policy_document" "codepipeline_role_policy" {
       "codebuild:BatchGetBuilds",
       "codebuild:StartBuild"
     ]
-    resources = ["*"]
+    resources = "arn:aws:codepipeline:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
   }
 }
 


### PR DESCRIPTION
Do this because this will fix the source_json error below:

```
│ Error: Unsupported argument
│ 
│   on .terraform/modules/deployment.deployment_bucket/main.tf line 8, in data "aws_iam_policy_document" "bucket_policy":
│    8:   source_json = var.policy
│ 
│ An argument named "source_json" is not expected here.
╵
```